### PR TITLE
config():consistent filename with imports

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "noImplicitAny": false,
     "jsx": "preserve",
     "incremental": true,
+    "forceConsistentCasingInFileNames": true,
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
Then typescript will use different file imports according to the used operating system.
So if windows is used,then imports will understand case-insensitive filenames, but with Linux and MacOs (I think), then it will convert it to the correct filename.

## Why are you adding this?

Because @stinkyfish1 had a problem earlier with imports. This was solved without adding this config fix, however, this is a more robust way with handling case sensitive file names in imports.