### PR TITLE
fix: Reduce searchbar animation durations and respect prefers-reduced-motion

### DIFF
--- a/components/ui/search-bar.tsx
+++ b/components/ui/search-bar.tsx
@@ -13,7 +13,22 @@ export default function SearchBar() {
     const [input, setInput] = useState("")
     const [response, setResponse] = useState<SearchResult>([])
     const [debouncedInput] = useDebounce(input, 400)
-    const [animationParent] = useAutoAnimate()
+    
+    // Check if user prefers reduced motion
+    const prefersReducedMotion = 
+        typeof window !== 'undefined' && 
+        window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    
+    // Configure auto-animate with faster durations and respect user's motion preferences
+    const [animationParent] = useAutoAnimate({
+        duration: prefersReducedMotion ? 0 : 150, // Reduced from default 250ms to 150ms
+        easing: 'ease-in-out'
+    })
+    
+    const [resultsParent] = useAutoAnimate({
+        duration: prefersReducedMotion ? 0 : 100, // Fast appearance for search results
+        easing: 'ease-out'
+    })
 
     const {setNodes, setEdges} = useFlowStore()
 
@@ -42,6 +57,14 @@ export default function SearchBar() {
             setEdges(edges)
         }
     }
+    
+    const handleBlur = () => {
+        // Adjust delay based on animation preferences
+        // If animations are disabled, no delay is needed
+        const delay = prefersReducedMotion ? 0 : 150
+        setTimeout(() => setIsFocused(false), delay)
+    }
+    
     function iconLogic(item) {
         return (
             (() => {
@@ -83,11 +106,11 @@ export default function SearchBar() {
                 onChange={(e) => setInput(e.target.value)}
                 value={input}
                 onFocus={() => (setIsFocused(true))}
-                onBlur={() => setTimeout(() => setIsFocused(false), 250)}
+                onBlur={handleBlur}
                 placeholder="Search for components by name…"
             />
                 {isFocused ?
-                    <ul className="p-2 max-h-96 overflow-y-scroll rounded-b-md border-none shadow-2xl">
+                    <ul ref={resultsParent} className="p-2 max-h-96 overflow-y-scroll rounded-b-md border-none shadow-2xl">
                         {response.map((item) => (
                             <article className="w-full h-10 gap-3 bg-white flex flex-row hover:bg-neutral-100 hover:cursor-pointer hover: p-2 rounded-lg"
                                      key={item.id}


### PR DESCRIPTION
## Description
This PR addresses issue #87 by optimizing searchbar animation performance and improving accessibility support.

## Problem
The current searchbar animations were too slow (250ms), making the user experience feel sluggish and annoying. Additionally, users with animations disabled in their OS settings experienced an unnecessary delay when closing the searchbar.

## Solution
✨ **Reduced animation durations**:
- Main searchbar container: 250ms → 150ms (40% faster)
- Search results appearance: added dedicated 100ms animation

♿ **Added accessibility support**:
- Implemented `prefers-reduced-motion` media query detection
- Animations automatically disabled (0ms) when user has reduced motion enabled
- Dynamic blur delay: 0ms when animations disabled, 150ms when enabled

## Changes Made
- Configured `useAutoAnimate` hooks with custom duration and easing
- Added `prefersReducedMotion` detection using `window.matchMedia`
- Created `handleBlur()` function with dynamic delay adjustment
- Applied separate animation config for search results list

## Testing
- [x] Code compiles without errors
- [x] No TypeScript errors
- [ ] Tested with animations enabled - faster and smoother
- [ ] Tested with Windows Accessibility settings (Animation effects OFF) - no delay

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which improves UX)
- [x] Accessibility improvement

## Screenshots/GIFs
_Please test and add before/after comparison if possible_

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have added appropriate context in commit messages

## Related Issues
Fixes #87

---
**Note to reviewers**: To test the accessibility feature, go to Windows Settings → Accessibility → Visual Effects → Turn OFF "Animation effects", then test the searchbar close behavior.