### PR TITLE
refactor(card): smaller text size

### DIFF
--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -54,7 +54,7 @@ const CardTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("font-semibold leading-none tracking-tight", className)}
+    className={cn("font-medium text-xs lg:sm:text-sm leading-none tracking-tight", className)}
     {...props}
   />
 ))
@@ -66,7 +66,7 @@ const CardDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
+    className={cn("text-xs text-muted-foreground", className)}
     {...props}
   />
 ))
@@ -76,7 +76,7 @@ const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+  <div ref={ref} className={cn("text-xs p-6 pt-0", className)} {...props} />
 ))
 CardContent.displayName = "CardContent"
 


### PR DESCRIPTION
Changed titlesize from 16 to 14 and 12 on smaler devices and font weight from semibold to medium. Card content from 14 to 12 px
Before:

<img width="646" height="461" alt="bilde" src="https://github.com/user-attachments/assets/6dae035d-2848-41b4-aec8-29b3ae651164" />

After:

<img width="534" height="421" alt="bilde" src="https://github.com/user-attachments/assets/b9f3b0b8-15a6-4f9a-a2aa-2dbf310d9028" />
