### PR TITLE
fix(description): remove properties description

### DIFF
--- a/components/btn-group-component.tsx
+++ b/components/btn-group-component.tsx
@@ -56,7 +56,6 @@ export default function BtnGroupComponent({equipment, handleExpand}: BtnGroupCom
 
         {/* Description: controlled */}
         <Description
-          description={(equipment as any)?.description}
           open={openThing === "description"}
           onOpenChange={(open) =>
             setOpenThing((prev) => (open ? "description" : prev === "description" ? null : prev))


### PR DESCRIPTION
The description in the properties dropdown was seen in the separate description dropdown, so i removed it