### PR TITLE
feat(gallery): icon in explanitory title + removed 10px mt

### DIFF
--- a/app/gallery/page.tsx
+++ b/app/gallery/page.tsx
@@ -91,8 +91,11 @@ export default async function Home() {
                         presentation={presentation}
                     />
                 </div>
-                <div className="w-3/4 mt-[10px]">
-                    <span className="font-bold">{splitTitle(equipment.rdfType)}</span>
+                <div className="w-3/4">
+                    <span className="font-bold flex w-full gap-2">
+                        {presentation.icon}
+                        {splitTitle(equipment.rdfType)}
+                    </span>
                     <p>{componentDescriptionMap.get(equipment.rdfType)}</p>
                 </div>
             </div>


### PR DESCRIPTION
Icon was placed by the explanitory title.

The reason for this, is that I don't think it would make sense to have it in the component, by the title, as that would show two different component stylings. This could make it unclear, and add more conditional behavior into `generic-component`, which already has enough responsibility. This page is only for explanation, and in my opinion, should not affect actual component's complexity. 


<img width="1249" height="575" alt="image" src="https://github.com/user-attachments/assets/72e60e9a-04d2-4612-a77f-7ee293a38d3b" />
